### PR TITLE
Add socket.request.max.bytes setting

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,9 +16,11 @@
 set -e
 
 BUILD_DIRECTORY="$(date +%s)"
-KAFKA_MIRROR="${KAFKA_MIRROR:-http://www-us.apache.org/dist/kafka}"
+KAFKA_MIRROR="${KAFKA_MIRROR:-https://archive.apache.org/dist/kafka}"
 KAFKA_VERSION="${KAFKA_VERSION:-2.1.0}"
 SCALA_VERSION="${SCALA_VERSION:-2.11}"
+
+SOCKET_REQUEST_MAX_BYTES="${SOCKET_REQUEST_MAX_BYTES:-104857600}"
 
 mkdir -p "${BUILD_DIRECTORY}"
 

--- a/etc/kafka/server.properties
+++ b/etc/kafka/server.properties
@@ -51,7 +51,7 @@ socket.send.buffer.bytes=102400
 socket.receive.buffer.bytes=102400
 
 # The maximum size of a request that the socket server will accept (protection against OOM)
-socket.request.max.bytes=104857600
+socket.request.max.bytes=${SOCKET_REQUEST_MAX_BYTES}
 
 
 ############################# Log Basics #############################


### PR DESCRIPTION
Also fix mirror URL, now that this version has been archived.

We used `socket.request.max.bytes` while debugging https://github.com/DecipherNow/gm-proxy/issues/550.